### PR TITLE
Jason/no email in db key

### DIFF
--- a/src/components/Firebase/firebase.jsx
+++ b/src/components/Firebase/firebase.jsx
@@ -32,8 +32,8 @@ class Firebase {
     this.db = app.database(app);
 
     // Database references
-    this.user = email => this.db.ref(`users/${email}`);
     this.users = () => this.db.ref("users/");
+    this.usersByUid = uid => this.db.ref(`users/${uid}`);
 
     this.glossary = () => this.db.ref("glossary/");
     this.glossaryByUid = uid => this.db.ref(`glossary/${uid}`);

--- a/src/components/Settings/settings.jsx
+++ b/src/components/Settings/settings.jsx
@@ -87,9 +87,9 @@ class Settings extends Component {
       snackbarOpen: false,
       snackbarText: "",
       loading: true,
-      emailList,
+      emailList: null,
       emailToEnabled: null,
-      emailToUid,
+      emailToUid: null
     };
     this.onEmailInputChange = this.onEmailInputChange.bind(this);
 
@@ -150,7 +150,6 @@ class Settings extends Component {
       }
 
       this.setState({ emailList: new Array(0), loading: false });
-
     });
   }
 
@@ -205,7 +204,9 @@ class Settings extends Component {
         });
       })
       .then(() => {
-        this.handleShowSnackbar(`Successfully invited admin with email ${emailInput}`);
+        this.handleShowSnackbar(
+          `Successfully invited admin with email ${emailInput}`
+        );
       })
       .catch(error => {
         const errorCode = error.code;
@@ -324,10 +325,21 @@ class Settings extends Component {
 
   writeUserToDb(email, enabled) {
     const { firebase } = this.props;
+    const { emailList, emailToUid } = this.state;
 
-    return firebase.user().push({
-      email: email,
-      enabled: enabled,
+    if (emailList.indexOf(email) === -1) {
+      // This is a new user. We must push a new node to the firebase
+      // realtime DB
+      return firebase.users().push({
+        email,
+        enabled
+      });
+    }
+
+    // else, this user already exists. We are simply changing their enabled status
+    return firebase.usersByUid(emailToUid[email]).set({
+      email,
+      enabled
     });
   }
 

--- a/src/components/SignIn/signIn.jsx
+++ b/src/components/SignIn/signIn.jsx
@@ -48,7 +48,6 @@ const INITIAL_STATE = {
   password: "",
   emailList: null,
   emailToEnabled: null,
-  emailToUid: null,
   error: null
 };
 
@@ -89,26 +88,22 @@ class SignInFormBase extends Component {
       if (snapshotObject) {
         const emailList = new Array(0);
         const emailToEnabled = {};
-        const emailToUid = {};
 
         Object.keys(snapshotObject).forEach(uid => {
           const snapshotEntry = snapshotObject[uid];
           emailList.push(snapshotEntry.email);
           emailToEnabled[snapshotEntry.email] = snapshotEntry.enabled;
-          emailToUid[snapshotEntry.email] = uid;
         });
 
         this.setState({
           emailList,
-          emailToEnabled,
-          emailToUid,
+          emailToEnabled
         });
 
         return;
       }
 
-      this.setState({ emailList: new Array(0)});
-
+      this.setState({ emailList: new Array(0) });
     });
   }
 


### PR DESCRIPTION
We needed to restructure the `users` firebase node.
Reason: Previously, we attempted to use email addresses as keys into the DB node. We used `.replace()` to replace `.` characters in emails, with `,`. This was safe since `.` is not allowed in email addresses. However, note that `.replace()` only replaces the first instance of a character. To avoid having to do more complicated replaces, and also to make the code cleaner, we store users under a randomized key (provided by `firebase.push()`), and store `email` and `enabled` in individual fields.

In addition, I have already updated the Firebase DB `users` node to match the format expected by this PR.